### PR TITLE
Remove unused API preload link

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -12,7 +12,6 @@
     <link rel="apple-touch-icon" href="./images/icons/maskable_icon_x512.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://rento-backend-api-d6zuozodga-et.a.run.app" as="fetch">
 </head>
 <body>
     <a href="#main-content" class="skip-link">Skip to Content</a>


### PR DESCRIPTION
This pull request removes the unused API preload link from the HTML file.